### PR TITLE
AUTO-3005: Add target to live_type_ahead

### DIFF
--- a/lib/components/live_helpers.ex
+++ b/lib/components/live_helpers.ex
@@ -90,6 +90,7 @@ defmodule CrunchBerry.Components.LiveHelpers do
   - `search_text` - required - this value will be used as the value for the input
   - `search_results` - required - a list of results from you typeahead search function the require type is `[{integer(), String.t()}]`
   - `current_focus` - required - a integer pointing to the index of the focused search_result, it shoud default to -1
+  - `target` - required - an HTML selector that refers to the particular usage instance of the typeahead
   - `placeholder` - optional - You can optionally pass in placeholder text otherwise it defaults to "Searching..."
 
   ## Examples

--- a/lib/components/type_ahead.ex
+++ b/lib/components/type_ahead.ex
@@ -12,12 +12,13 @@ defmodule CrunchBerry.Components.TypeAhead do
           label: String.t(),
           search_text: String.t(),
           search_results: [] | [{integer(), String.t()}],
-          current_focus: integer()
+          current_focus: integer(),
+          target: String.t()
         }
 
   @doc """
-  The render function requires the form Struct, a search string, and search_results. The placeholder
-  key is optional and defautls to "Search...".
+  The render function requires the form Struct, a search string, a target, and search_results. The placeholder
+  key is optional and defaults to "Search...".
   """
   @spec render(args()) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
@@ -43,7 +44,8 @@ defmodule CrunchBerry.Components.TypeAhead do
           <li class="w-full px-2 py-3 cursor-pointer hover:bg-blue-3 hover:text-white <%=is_focus?(idx, assigns) %>"
               phx-click="type-ahead-select"
               phx-value-type-ahead-result-id="<%= id %>"
-              phx-value-type-ahead-result="<%= result %>">
+              phx-value-type-ahead-result="<%= result %>"
+              phx-target="<%= assigns.target %>">
             <%= raw format_search_result(result, assigns.search_text) %>
           </li>
         <% end %>


### PR DESCRIPTION
Adding a target to the live component typeahead field so that multiple instances of this component on the same page can direct the events to the appropriate instance.

Usage example with a target:
`        <%= live_type_ahead(form: f, label: "Email", search_text: @search_text, search_results: @search_results, current_focus: @current_focus, placeholder: "name or e-mail address...", target: @myself)  %>`
       