### PR TITLE
AUTO-3005: fix component for backwards compatibility

### DIFF
--- a/lib/components/live_helpers.ex
+++ b/lib/components/live_helpers.ex
@@ -90,7 +90,7 @@ defmodule CrunchBerry.Components.LiveHelpers do
   - `search_text` - required - this value will be used as the value for the input
   - `search_results` - required - a list of results from you typeahead search function the require type is `[{integer(), String.t()}]`
   - `current_focus` - required - a integer pointing to the index of the focused search_result, it shoud default to -1
-  - `target` - required - an HTML selector that refers to the particular usage instance of the typeahead
+  - `target` - optional - an HTML selector that refers to the particular usage instance of the typeahead
   - `placeholder` - optional - You can optionally pass in placeholder text otherwise it defaults to "Searching..."
 
   ## Examples

--- a/lib/components/type_ahead.ex
+++ b/lib/components/type_ahead.ex
@@ -13,7 +13,7 @@ defmodule CrunchBerry.Components.TypeAhead do
           search_text: String.t(),
           search_results: [] | [{integer(), String.t()}],
           current_focus: integer(),
-          target: String.t()
+          target: %Phoenix.LiveComponent.CID{}
         }
 
   @doc """
@@ -26,7 +26,7 @@ defmodule CrunchBerry.Components.TypeAhead do
     <div class="px-3 mb-6 md:mb-0" >
       <div class="relative w-full" phx-debounce="blur">
         <%= label assigns.form, assigns.label %>
-        <input class="w-full" type="text" name="type_ahead_search" value="<%= assigns.search_text %>" phx-debounce="500" placeholder="<%= place_holder_or_default(assigns) %>" autocomplete="off" phx-blur="type-ahead-blur"/>
+        <input class="w-full" type="text" name="type_ahead_search" value="<%= assigns.search_text %>" phx-debounce="500" placeholder="<%= place_holder_or_default(assigns) %>" autocomplete="off" phx-blur="type-ahead-blur" <%= phx_target(assigns) %>/>
 
         <%= if show_results?(assigns) do %>
           <%= do_render_drop_down(assigns) %>
@@ -39,13 +39,13 @@ defmodule CrunchBerry.Components.TypeAhead do
   defp do_render_drop_down(assigns) do
     ~L"""
     <div class="absolute z-10 flex flex-col items-start w-full bg-white shadow-md mt-1" role="menu">
-      <ul class="flex flex-col w-full" phx-window-keydown="type-ahead-set-focus">
+      <ul class="flex flex-col w-full" phx-window-keydown="type-ahead-set-focus" <%= phx_target(assigns) %>>
         <%= for {{id, result}, idx} <- Enum.with_index(assigns.search_results) do %>
           <li class="w-full px-2 py-3 cursor-pointer hover:bg-blue-3 hover:text-white <%=is_focus?(idx, assigns) %>"
               phx-click="type-ahead-select"
               phx-value-type-ahead-result-id="<%= id %>"
               phx-value-type-ahead-result="<%= result %>"
-              phx-target="<%= assigns.target %>">
+              <%= phx_target(assigns) %>>
             <%= raw format_search_result(result, assigns.search_text) %>
           </li>
         <% end %>
@@ -72,4 +72,7 @@ defmodule CrunchBerry.Components.TypeAhead do
       "<strong>#{match}</strong>"
     end)
   end
+
+  defp phx_target(%{target: target}), do: "phx-target=\"#{target}\""
+  defp phx_target(_), do: nil
 end


### PR DESCRIPTION
Fixing the typeahead so that existing usages won't break without a target specified