### PR TITLE
AUTO 3070: adding an id to the results for testing

### DIFF
--- a/lib/components/type_ahead.ex
+++ b/lib/components/type_ahead.ex
@@ -22,6 +22,8 @@ defmodule CrunchBerry.Components.TypeAhead do
   """
   @spec render(args()) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
+    assigns.form |> IO.inspect(label: "WHAAA")
+
     ~L"""
     <div class="px-3 mb-6 md:mb-0" >
       <div class="relative w-full" phx-debounce="blur">
@@ -42,6 +44,7 @@ defmodule CrunchBerry.Components.TypeAhead do
       <ul class="flex flex-col w-full" phx-window-keydown="type-ahead-set-focus" <%= phx_target(assigns) %>>
         <%= for {{id, result}, idx} <- Enum.with_index(assigns.search_results) do %>
           <li class="w-full px-2 py-3 cursor-pointer hover:bg-blue-3 hover:text-white <%=is_focus?(idx, assigns) %>"
+              id = "<%= assigns.form.id%>_<%= id %>"
               phx-click="type-ahead-select"
               phx-value-type-ahead-result-id="<%= id %>"
               phx-value-type-ahead-result="<%= result %>"

--- a/lib/components/type_ahead.ex
+++ b/lib/components/type_ahead.ex
@@ -22,8 +22,6 @@ defmodule CrunchBerry.Components.TypeAhead do
   """
   @spec render(args()) :: Phoenix.LiveView.Rendered.t()
   def render(assigns) do
-    assigns.form |> IO.inspect(label: "WHAAA")
-
     ~L"""
     <div class="px-3 mb-6 md:mb-0" >
       <div class="relative w-full" phx-debounce="blur">


### PR DESCRIPTION
Currently, we need a way to identify a specific list item to click on in a test.

Adding the for loop id to the id for the typeahead. The id should be the database id that is returned when used in practice.