### PR TITLE
Add more overridable styles for the pagination component

### DIFF
--- a/lib/components/live_helpers.ex
+++ b/lib/components/live_helpers.ex
@@ -48,7 +48,14 @@ defmodule CrunchBerry.Components.LiveHelpers do
     In order to customize the look and feel, you may pass in a map.  The following keys are supported:
 
     - active - Classes applied to the currently active page.
-    - text - Classes applied to all children, except the currently active page.
+    - ellipsis - Classes applied to the "..." ellipsis page gap.
+    - first - Classes applied to the first pagination button ("<<" (previous) or page number 1).
+    - last - Classes applied to the last pagination button (">>" (next) or last page number).
+    - list - Classes applied to the containing list.
+    - next - Classes applied to the ">>" next button.
+    - page - Classes applied to page buttons other than the "<<" previous and ">>" next buttons.
+    - previous - Classes applied to the "<<" previous button.
+    - text - Classes applied to all children, except the currently active page and the ellipsis page gap.
 
     ## Pagination
 


### PR DESCRIPTION
Adds support for additional CSS classes that can be customized for the pagination component (similar to #14 for the type ahead component).

I did remove the `list-reset` and `pl-0` classes from the `ul` element as Tailwind already resets styles on lists. I also removed the `relative` class from the page button as it appeared to not be doing anything useful for the template.

Finally, I noticed that there was a visual bug where page buttons were being rounded when the last page was selected.
<img width="598" alt="pagination-visual-bug" src="https://user-images.githubusercontent.com/1349/141374880-6102e588-d40c-409c-9d89-3db0e7535d06.png">

This has been corrected as well.
<img width="589" alt="pagination-visual-bug-fix" src="https://user-images.githubusercontent.com/1349/141374949-9e6b9abd-78b9-4b44-b9fe-72f850d9956d.png">
