### PR TITLE
Do not show pagination when there are zero total pages

### DIFF
--- a/lib/components/pagination.ex
+++ b/lib/components/pagination.ex
@@ -57,7 +57,7 @@ defmodule CrunchBerry.Components.Pagination do
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
-    <%= unless @page.total_pages == 1 do %>
+    <%= unless @page.total_pages <= 1 do %>
     <nav aria-label={@name}>
       <ul class={@classes[:list]}>
         <%= if @page.page_number > 1 do %>


### PR DESCRIPTION
Fixes bug when the page has zero total pages. So, rather than showing something like this:

<img width="87" alt="pagination-zero-total-pages-bug" src="https://user-images.githubusercontent.com/1349/141518959-a130765c-f3a2-4723-a53b-47437a63ae0c.png">

an empty template is returned.


