### PR TITLE
Adds overridable styles for modal component

### DIFF
--- a/lib/components/live_helpers.ex
+++ b/lib/components/live_helpers.ex
@@ -17,13 +17,32 @@ defmodule CrunchBerry.Components.LiveHelpers do
 
   - `id` - required.  The modal is a `Phoenix.LiveComponent`, and needs a specified `id`.
   - `return_to` - required.  This is the route that will be pushed to when the modal is closed,
-  either by the "x" or clicking the background.
+     either by the "x" or clicking the background.
+  - `classes` - overrides to customize the look and feel.  See classes below.
+
+  ## Classes
+  In order to customize the look and feel, you may pass in a map.  The following keys are supported,
+  from outer to inner:
+
+  - component - Classes applied to the outermost component div, with id of @id. By default it is
+    full width and height.
+    default: fixed inset-0 w-full h-full z-20 bg-black bg-opacity-50 overflow-y-auto flex
+             items-center backdrop-filter backdrop-blur-sm
+  - container - Classes applied to the container that sets the width of the modal (11/12 with a max of
+    max-w-md.
+    default: relative mx-auto my-10 opacity-100 w-11/12 md:max-w-md rounded overflow-y-auto
+  - background - Classes applied to the next container that sets the background color.
+    default: relative bg-white shadow-lg rounded-md text-gray-900 z-20 flow-root
+  - cancel_icon - Classes applied to the top right cancel icon (&times;)
+    default: text-gray-400 text-2xl absolute top-0 right-0 py-1 px-3 rounded-full cursor-pointer
+    hover:no-underline hover:text-black duration-50
 
   ## Examples
 
       <%= live_modal MyProjectWeb.WidgetLive.FormComponent,
         id: :new,
-        return_to: Routes.widget_index_path(@socket, :index)
+        return_to: Routes.widget_index_path(@socket, :index),
+        classes: %{ container: "relative mx-auto my-10 opacity-100 rounded overflow-x-auto" }
         # Any option besides id/return_to is passed through to the child component,
         # this is where you can pass in any assigns the child component is going to need.
         action: @live_action
@@ -33,7 +52,10 @@ defmodule CrunchBerry.Components.LiveHelpers do
           Phoenix.LiveView.Component.t()
   def live_modal(component, opts) do
     path = Keyword.fetch!(opts, :return_to)
+    classes = Keyword.get(opts, :classes, nil)
     modal_opts = [id: :modal, return_to: path, component: component, opts: opts]
+    modal_opts = if classes, do: Keyword.merge(modal_opts, classes: classes), else: modal_opts
+
     live_component(Modal, modal_opts)
   end
 

--- a/lib/components/modal.ex
+++ b/lib/components/modal.ex
@@ -5,12 +5,36 @@ defmodule CrunchBerry.Components.Modal do
   use Phoenix.HTML
   use Phoenix.LiveComponent
 
+  @classes_defaults %{
+    component:
+      "fixed inset-0 w-full h-full z-20 bg-black bg-opacity-50 overflow-y-auto flex items-center backdrop-filter backdrop-blur-sm",
+    container: "relative mx-auto my-10 opacity-100 w-11/12 md:max-w-md rounded overflow-y-auto",
+    background: "relative bg-white shadow-lg rounded-md text-gray-900 z-20 flow-root",
+    cancel_icon:
+      "text-gray-400 text-2xl absolute top-0 right-0 py-1 px-3 rounded-full cursor-pointer hover:no-underline hover:text-black duration-50"
+  }
+
+  @impl Phoenix.LiveComponent
+  def update(assigns, socket) do
+    classes =
+      assigns
+      |> Map.get(:classes, %{})
+      |> then(fn classes -> Map.merge(@classes_defaults, classes) end)
+
+    socket =
+      socket
+      |> assign(assigns)
+      |> assign(:classes, classes)
+
+    {:ok, socket}
+  end
+
   @impl Phoenix.LiveComponent
   def render(assigns) do
     ~H"""
     <div
       id={@id}
-      class="fixed inset-0 w-full h-full z-20 bg-black bg-opacity-50 overflow-y-auto flex items-center backdrop-filter backdrop-blur-sm"
+      class={@classes[:component]}
       tabindex="-1"
       role="dialog"
       aria-labelledby={"#{@id}Label"}
@@ -20,10 +44,10 @@ defmodule CrunchBerry.Components.Modal do
       phx-key="escape"
       phx-target={"##{@id}"}
       phx-page-loading>
-        <div class="relative mx-auto my-10 opacity-100 w-11/12 md:max-w-md rounded overflow-y-auto">
-          <div class="relative bg-white shadow-lg rounded-md text-gray-900 z-20 flow-root">
+        <div class={@classes[:container]}>
+          <div class={@classes[:background]}>
            <div>
-             <%= live_patch raw("&times;"), to: @return_to, aria_hidden: true, class: "text-gray-400 text-2xl absolute top-0 right-0 py-1 px-3 rounded-full cursor-pointer hover:no-underline hover:text-black duration-50", title: "Close" %>
+             <%= live_patch raw("&times;"), to: @return_to, aria_hidden: true, class: @classes[:cancel_icon], title: "Close" %>
            </div>
            <%= live_component @component, @opts %>
           </div>

--- a/test/components/confirm_modal_test.exs
+++ b/test/components/confirm_modal_test.exs
@@ -1,4 +1,4 @@
-defmodule Optimizer.Api.UserLive.UploadSalesCSV.ConfirmModalTest do
+defmodule CrunchBerry.Components.ConfirmModalTest do
   use CrunchBerry.ComponentCase
 
   alias CrunchBerry.Components.ConfirmModal

--- a/test/components/flash_message_test.exs
+++ b/test/components/flash_message_test.exs
@@ -1,4 +1,4 @@
-defmodule Optimizer.Api.UserLive.UploadSalesCSV.FlashMessageTest do
+defmodule CrunchBerry.Components.FlashMessageTest do
   use CrunchBerry.ComponentCase
 
   describe "Renders in a view" do

--- a/test/components/modal_test.exs
+++ b/test/components/modal_test.exs
@@ -1,0 +1,54 @@
+defmodule CrunchBerry.Components.ModalTest do
+  use CrunchBerry.ComponentCase
+
+  import Phoenix.LiveView.Helpers
+
+  alias CrunchBerry.Components.Modal
+
+  defmodule FixtureComponent do
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <p>Hello</p>
+      """
+    end
+  end
+
+  describe "render/1" do
+    test "applies classes" do
+      modal_opts = [
+        id: :modal,
+        return_to: "/mumble",
+        component: FixtureComponent,
+        classes: %{
+          component: "component-classes",
+          container: "container-classes",
+          background: "background-classes",
+          cancel_icon: "cancel_icon-classes"
+        },
+        opts: %{}
+      ]
+
+      html = render_component(Modal, modal_opts)
+
+      {:ok, doc} = Floki.parse_document(html)
+
+      assert doc
+             |> Floki.find("#modal")
+             |> Floki.attribute("class") == ["component-classes"]
+
+      assert doc
+             |> Floki.find("#modal > div")
+             |> Floki.attribute("class") == ["container-classes"]
+
+      assert doc
+             |> Floki.find("#modal > div > div")
+             |> Floki.attribute("class") == ["background-classes"]
+
+      assert doc
+             |> Floki.find("#modal > div > div > div > a")
+             |> Floki.attribute("class") == ["cancel_icon-classes"]
+    end
+  end
+end


### PR DESCRIPTION
This enables overriding of the classes on the Modal component. I copied the overriding of classes strategy used in the Pagination component. 

In addition, I noticed some test module names that were unexpected. I changed them to idiomatic test module names in a separate commit. 

This should be a non-breaking change. Existing code is expected to work without change.

