### PR TITLE
Fixes setting id on Modal

### DIFF
--- a/lib/components/live_helpers.ex
+++ b/lib/components/live_helpers.ex
@@ -33,7 +33,8 @@ defmodule CrunchBerry.Components.LiveHelpers do
           Phoenix.LiveView.Component.t()
   def live_modal(component, opts) do
     path = Keyword.fetch!(opts, :return_to)
-    modal_opts = [id: :modal, return_to: path, component: component, opts: opts]
+    id = Keyword.fetch!(opts, :id)
+    modal_opts = [id: id, return_to: path, component: component, opts: opts]
     live_component(Modal, modal_opts)
   end
 

--- a/test/components/live_helpers_test.exs
+++ b/test/components/live_helpers_test.exs
@@ -1,0 +1,45 @@
+defmodule CrunchBerry.Components.LiveHelpersTest do
+  use CrunchBerry.ComponentCase
+
+  import CrunchBerry.Components.LiveHelpers
+  import Phoenix.LiveViewTest
+
+  describe "live_modal" do
+    test "provides appropriate assigns" do
+      %{assigns: assigns} =
+        live_modal(ModalComponentFixture, id: :random_modal_id, return_to: "/mumble")
+
+      assert assigns.component == ModalComponentFixture
+      assert assigns.id == :random_modal_id
+      assert assigns.return_to == "/mumble"
+    end
+
+    defmodule FixtureComponent do
+      use Phoenix.LiveComponent
+
+      def render(assigns) do
+        ~H"""
+        <p>Hello</p>
+        """
+      end
+    end
+
+    defmodule LiveViewFixture do
+      use Phoenix.LiveView
+
+      def render(assigns) do
+        ~H"""
+        <%= live_modal FixtureComponent,
+        id: :random_modal_id,
+        return_to: "/mumble" %>
+        """
+      end
+    end
+
+    test "renders with id and return_to", %{conn: conn} do
+      {:ok, view, _html} = live_isolated(conn, LiveViewFixture)
+      assert has_element?(view, "#random_modal_id")
+      assert has_element?(view, ~s|a[href="/mumble"]|)
+    end
+  end
+end


### PR DESCRIPTION
`live_modal` was not setting the provided id with the modal. 

```
        <%= live_modal FixtureComponent,
        id: :random_modal_id,
        return_to: "/mumble" %>
```

Before this commit, the id on the modal would be "modal", not "random_modal_id".

This is probably a breaking change in some cases.