### PR TITLE
Allow clickaway events to be handled

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 # Used by "mix format"
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:phoenix],
   plugins: [Phoenix.LiveView.HTMLFormatter]
 ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,3 +6,9 @@ config :phoenix, :json_library, Jason
 config :crunch_berry, CrunchBerry.TestEndpoint,
   secret_key_base: "oc2RUnRoYkZlR0dM7JwlpbM9AsauRm0R1n+sUP71YsY9eflg4uWyeVFXHrAzDXL7",
   live_view: [signing_salt: "FqRkKpuzaujIZQGN"]
+
+# capture all logs
+config :logger, level: :debug
+
+# but only output warnings+ to console.
+config :logger, :console, level: :warn

--- a/lib/components/local_datetime.ex
+++ b/lib/components/local_datetime.ex
@@ -27,7 +27,6 @@ defmodule CrunchBerry.Components.LocalDateTime do
 
   @default_format "{Mshort} {D}, {YY} {h12}:{m}{am}"
 
-  @doc false
   @spec local_datetime(map()) :: any()
   def local_datetime(assigns) when not is_map_key(assigns, :date) do
     raise "`date` assign must be provided"

--- a/lib/components/modal.ex
+++ b/lib/components/modal.ex
@@ -31,6 +31,8 @@ defmodule CrunchBerry.Components.Modal do
 
   @impl Phoenix.LiveComponent
   def render(assigns) do
+    phx_target = Map.get(assigns, :phx_target, "id")
+
     ~H"""
     <div
       id={@id}
@@ -42,7 +44,7 @@ defmodule CrunchBerry.Components.Modal do
       phx-capture-click="close"
       phx-window-keydown="close"
       phx-key="escape"
-      phx-target={"##{@id}"}
+      phx-target={"##{phx_target}"}
       phx-page-loading
     >
       <div class={@classes[:container]}>

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule CrunchBerry.MixProject do
   def project do
     [
       app: :crunch_berry,
-      version: "0.4.0",
+      version: "0.4.1",
       elixir: "~> 1.10",
       elixirc_paths: elixirc_paths(Mix.env()),
       config_path: "./config/config.exs",

--- a/test/integration_test/modal_test.exs
+++ b/test/integration_test/modal_test.exs
@@ -1,0 +1,87 @@
+defmodule CrunchBerry.IntegrationTest.ModalTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.ConnTest
+  import Phoenix.LiveViewTest
+
+  alias CrunchBerry.Router
+  alias CrunchBerry.TestEndpoint
+
+  @endpoint TestEndpoint
+
+  setup do
+    conn =
+      Phoenix.ConnTest.build_conn(:get, "http://www.example.com/", nil)
+      |> Phoenix.ConnTest.bypass_through(Router, [:browser])
+      |> get("/modal")
+
+    {:ok, conn: conn}
+  end
+
+  describe "closing the modal" do
+    test "with return_to defined, returns to return_to", %{conn: conn} do
+      # The test liveview assigns all params to assigns, and displays
+      # the modal based on "show". Initially show is true, but the return_to
+      # path does not include a show.
+      {:ok, view, html} = live(conn, "/modal?return_to=/modal&show=true")
+      assert html =~ "The LiveView"
+      assert html =~ "The Modal"
+
+      html =
+        view
+        |> element("a", "×")
+        |> render_click()
+
+      assert html =~ "The LiveView"
+      refute html =~ "The Modal"
+    end
+
+    test "with return_to undefined, and a phx_target, delivers event to target", %{conn: conn} do
+      {:ok, view, html} = live(conn, "/modal?phx_target=ModalLive&show=true")
+      assert html =~ "The LiveView"
+      assert html =~ "The Modal"
+      refute html =~ "wrapped modal got close event"
+
+      html =
+        view
+        |> element("button", "×")
+        |> render_click()
+
+      assert html =~ "The LiveView"
+      refute html =~ "The Modal"
+      assert html =~ "wrapped modal got close event"
+    end
+
+    test "with return_to and phx_target undefined, delivers event to the wrapped modal", %{
+      conn: conn
+    } do
+      {:ok, view, html} = live(conn, "/modal?show=true")
+      assert html =~ "The LiveView"
+      assert html =~ "The Modal"
+
+      html =
+        view
+        |> element("button", "×")
+        |> render_click()
+
+      assert html =~ "The LiveView"
+      refute html =~ "The Modal"
+    end
+
+    test "with return_to undefined, and a phx_target, handles key_down outside of modal", %{
+      conn: conn
+    } do
+      {:ok, view, html} = live(conn, "/modal?phx_target=ModalLive&show=true")
+      assert html =~ "The LiveView"
+      assert html =~ "The Modal"
+
+      html =
+        view
+        |> element("#modal")
+        |> render_keydown()
+
+      assert html =~ "The LiveView"
+      refute html =~ "The Modal"
+    end
+  end
+end

--- a/test/support/live_view_test/modal_live.ex
+++ b/test/support/live_view_test/modal_live.ex
@@ -1,0 +1,71 @@
+defmodule CrunchBerry.LiveViewTest.ModalLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  defmodule ModalComponent do
+    @moduledoc false
+    use Phoenix.LiveComponent
+
+    def render(assigns) do
+      ~H"""
+      <div id="the_modal">
+        <div data-test-id="modal-title">The Modal</div>
+      </div>
+      """
+    end
+
+    def handle_event("close", _params, socket) do
+      params =
+        socket.assigns.params
+        |> Map.delete("show")
+
+      socket = assign(socket, :params, params)
+      {:noreply, socket}
+    end
+  end
+
+  alias CrunchBerry.Components.LiveHelpers
+
+  def mount(params, _, socket) do
+    socket = assign(socket, :params, params)
+    {:ok, socket}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <div id="the_live_view">
+      <div data-test-id="view-title">The LiveView</div>
+      <%= if @params["show"] do %>
+        <%= cond do %>
+          <% @params["return_to"] -> %>
+            <%= LiveHelpers.live_modal(ModalComponent, id: "otter", return_to: @params["return_to"]) %>
+          <% @params["phx_target"] -> %>
+            <%= LiveHelpers.live_modal(ModalComponent, id: "otter", phx_target: @params["phx_target"]) %>
+          <% true -> %>
+            <%= LiveHelpers.live_modal(ModalComponent, id: "otter") %>
+        <% end %>
+      <% end %>
+      <%= if Map.has_key?(assigns, :message) do %>
+        <div data-test-id="message"><%= @message %></div>
+      <% end %>
+    </div>
+    """
+  end
+
+  def handle_event("close", _, socket) do
+    params =
+      socket.assigns.params
+      |> Map.delete("show")
+
+    socket =
+      socket
+      |> assign(:message, "wrapped modal got close event")
+      |> assign(:params, params)
+
+    {:noreply, socket}
+  end
+
+  def handle_params(params, _uri, socket) do
+    {:noreply, assign(socket, :params, params)}
+  end
+end

--- a/test/support/test_endpoint.ex
+++ b/test/support/test_endpoint.ex
@@ -1,6 +1,47 @@
+defmodule CrunchBerry.TestEndpointOverridable do
+  @moduledoc false
+  defmacro __before_compile__(_env) do
+    quote do
+      @parsers Plug.Parsers.init(
+                 parsers: [:urlencoded, :multipart, :json],
+                 pass: ["*/*"],
+                 json_decoder: Phoenix.json_library()
+               )
+
+      defoverridable call: 2
+
+      def call(conn, _) do
+        %{conn | secret_key_base: config(:secret_key_base)}
+        |> Plug.Parsers.call(@parsers)
+        |> Plug.Conn.put_private(:phoenix_endpoint, __MODULE__)
+        |> CrunchBerry.Router.call([])
+      end
+    end
+  end
+end
+
 defmodule CrunchBerry.TestEndpoint do
   @moduledoc """
   Fake endpoint for the purposes of running tests
   """
   use Phoenix.Endpoint, otp_app: :crunch_berry
+
+  @before_compile CrunchBerry.TestEndpointOverridable
+
+  socket("/live", Phoenix.LiveView.Socket)
+
+  defoverridable url: 0, script_name: 0, config: 1, config: 2, static_path: 1
+  def url, do: "http://localhost:4000"
+  def script_name, do: []
+  def static_path(path), do: "/static" <> path
+  def config(:otp_app), do: :crunch_berry
+  def config(:live_view), do: [signing_salt: "112345678212345678312345678412"]
+  def config(:secret_key_base), do: String.duplicate("57689", 50)
+  def config(:cache_static_manifest_latest), do: Process.get(:cache_static_manifest_latest)
+  def config(:pubsub_server), do: Phoenix.LiveView.PubSub
+  def config(:render_errors), do: [view: __MODULE__]
+  def config(:static_url), do: [path: "/static"]
+
+  def config(which), do: super(which)
+  def config(which, default), do: super(which, default)
 end

--- a/test/support/test_router.ex
+++ b/test/support/test_router.ex
@@ -22,5 +22,8 @@ defmodule CrunchBerry.Router do
 
   scope "/", CrunchBerry.LiveViewTest do
     pipe_through [:browser]
+
+    # integration modal
+    live("/modal", ModalLive)
   end
 end

--- a/test/support/test_router.ex
+++ b/test/support/test_router.ex
@@ -1,0 +1,26 @@
+defmodule CrunchBerry.Router do
+  @moduledoc """
+  Router test harness for testing LiveViews
+  """
+  use Phoenix.Router
+  import Phoenix.LiveView.Router
+
+  pipeline :setup_session do
+    plug Plug.Session,
+      store: :cookie,
+      key: "_live_view_key",
+      signing_salt: "/VEDsdfsffMnp5"
+
+    plug :fetch_session
+  end
+
+  pipeline :browser do
+    plug :setup_session
+    plug :accepts, ["html"]
+    plug :fetch_live_flash
+  end
+
+  scope "/", CrunchBerry.LiveViewTest do
+    pipe_through [:browser]
+  end
+end


### PR DESCRIPTION
These changes allow CrunchBerry.Modal clients to assign a target for the close event that
occurs when clicking away from a modal. Prior to this change, you could launch modals without 
a `return_to`, and if you clicked away from those modals, the `handle_event("close"` would attempt
to `push_patch` to assigns.return_to, causing an exception.

I wanted to add tests for this specific exception but did not find a normal way to test modal interactions. I settled
on creating a small phoenix app with tests for the modal. The app is included in the project under ./crunch_berry_test_app. To run the tests, you cd into that directory and `mix test`. Ultimately I hope we shift these tests into their proper home in `crunch_berry/test`.